### PR TITLE
Pagination of Messages

### DIFF
--- a/app/Livewire/Chat.php
+++ b/app/Livewire/Chat.php
@@ -23,6 +23,7 @@ class Chat extends Component
     public $currentlyEditingId = null;
 
     public $editedAttachments;
+    public $loadedMessages = 60;
 
     protected $listeners = [
         'messageReceived' => 'handleMessageReceived',
@@ -62,6 +63,9 @@ class Chat extends Component
         // Load the conversation
         $this->activeConversation = Conversation::with('messages')->findOrFail($id);
         $this->messageInput = '';
+
+        // Return loadedMessages to default value
+        $this->loadedMessages = 60;
 
         // Are there any unread messages in the conversation?
         if($this->activeConversation->getUnreadCount() > 0) {
@@ -384,6 +388,11 @@ class Chat extends Component
         return $groupedMessages;
     }
 
+    public function loadMoreMessages(): void
+    {
+        $this->loadedMessages += 20;
+    }
+
     public function render()
     {
         // Show most recently active conversations first
@@ -393,7 +402,7 @@ class Chat extends Component
 
         if($this->activeConversation) {
             // Group the messages
-            $messageGroups = $this->groupMessages($this->activeConversation->messages);
+            $messageGroups = $this->groupMessages($this->activeConversation->messages->slice(-$this->loadedMessages));
         } else {
             // If there is no active conversation, there are no messages to group
             $messageGroups = null;

--- a/resources/views/components/chat-area-inputs.blade.php
+++ b/resources/views/components/chat-area-inputs.blade.php
@@ -1,6 +1,6 @@
 <div class="flex flex-row items-center h-16 py-7 bg-white dark:bg-gray-800 w-full px-4 md:px-10">
     <div>
-        <button wire:click="$dispatch('openModal', { component: 'message-attachment', arguments: { activeConversation: {{ $activeConversation->id }} }})" class="flex items-center justify-center text-gray-400 hover:text-gray-600 transition">
+        <button wire:click="$dispatch('openModal', { component: 'message-attachment', arguments: { activeConversation: {{ $activeConversation->id }} }})" class="flex items-center justify-center text-gray-400 hover:text-gray-600 dark:hover:text-gray-100 transition">
             <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15.172 7l-6.586 6.586a2 2 0 102.828 2.828l6.414-6.586a4 4 0 00-5.656-5.656l-6.415 6.585a6 6 0 108.486 8.486L20.5 13"></path>
             </svg>

--- a/resources/views/components/chat-area.blade.php
+++ b/resources/views/components/chat-area.blade.php
@@ -24,6 +24,15 @@
                         @endforeach
                     </div>
 
+                    {{-- If there are any more messages to load --}}
+                    @if($loadedMessages < $activeConversation->messages->count())
+                        <div class="flex justify-center text-xs dark:text-gray-400 text-gray-600 my-10">
+                            <button wire:click="loadMoreMessages" class="text-xl font-sans text-center dark:text-gray-500 dark:hover:text-gray-200 transition">
+                                Load more messages
+                            </button>
+                        </div>
+                    @endif
+
                     @if($messageGroups->count() === 0)
                         <div class="mx-auto p-6">
                             <div class="text-xl font-sans text-center dark:text-gray-500">

--- a/resources/views/livewire/pages/chat.blade.php
+++ b/resources/views/livewire/pages/chat.blade.php
@@ -1,7 +1,7 @@
 <div class="flex antialiased text-gray-800">
     <div class="flex flex-row h-full w-full overflow-x-hidden">
         <x-side-list :conversations="$conversations" :activeConversation="$activeConversation"  />
-        <x-chat-area :messageGroups="$messageGroups" :activeConversation="$activeConversation" :currentlyEditingId="$currentlyEditingId"/>
+        <x-chat-area :messageGroups="$messageGroups" :activeConversation="$activeConversation" :currentlyEditingId="$currentlyEditingId" :loadedMessages="$loadedMessages"/>
     </div>
 </div>
 


### PR DESCRIPTION
Loading 60 messages by default and loading 20 more each time the load more messages button is clicked.

Ideally I would like to preserve scroll state but can't really justify the time investment into figuring out how to do this as have already spent a few hours on this problem alone, leaving it like this for now.